### PR TITLE
Fix version lookups for names containing reserved URI chars (e.g. `%40`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,11 @@ async function handleRequest(request, env, ctx, sentry) {
 
   try {
     const url = new URL(request.url);
-    const pathname = decodeURI(url.pathname);
+    // Keep pathname URL-encoded for routing; decode each captured segment
+    // individually below before using it as a KV key. `decodeURI` does NOT
+    // decode reserved chars like `@` (`%40`), which broke version lookups
+    // for names such as `scatterjs-core@2.7.18`.
+    const pathname = url.pathname;
 
     if (pathname === "/favicon.ico") {
       return not_found("not found");
@@ -110,7 +114,7 @@ async function handleRequest(request, env, ctx, sentry) {
     if (packages_endpoint !== null) {
       // Endpoint: `/packages/<package name>`.
       // Fetch package metadata from KV.
-      const { package_name } = packages_endpoint.groups;
+      const package_name = decodeURIComponent(packages_endpoint.groups.package_name);
       const package_json = await env.CDNJS_PACKAGES.get(package_name);
       if (package_json === null) {
         // Cache 404 package for an hour.
@@ -130,7 +134,11 @@ async function handleRequest(request, env, ctx, sentry) {
     if (pkg_sris_endpoint !== null) {
       // Endpoints: `/packages/<package name>/sris`, `/packages/<package name>/sris/<version name>`
       // Fetch SRIs for a package.
-      const { package_name, version_name } = pkg_sris_endpoint.groups;
+      const package_name = decodeURIComponent(pkg_sris_endpoint.groups.package_name);
+      const version_name =
+        pkg_sris_endpoint.groups.version_name === undefined
+          ? undefined
+          : decodeURIComponent(pkg_sris_endpoint.groups.version_name);
       let sris = {};
       for await (const { name, metadata } of get_all_keys(env.CDNJS_SRIS, {
         prefix: `${package_name}/${
@@ -152,7 +160,9 @@ async function handleRequest(request, env, ctx, sentry) {
     if (aggregated_metadata_endpoint !== null) {
       // Endpoint: `/packages/<package name>/all`.
       // Fetch aggregated metadata for a package.
-      const { package_name } = aggregated_metadata_endpoint.groups;
+      const package_name = decodeURIComponent(
+        aggregated_metadata_endpoint.groups.package_name
+      );
       const aggregated_gzip = await env.CDNJS_AGGREGATED_METADATA.get(
         package_name,
         "arrayBuffer"
@@ -177,7 +187,7 @@ async function handleRequest(request, env, ctx, sentry) {
     if (versions_endpoint !== null) {
       // Endpoint: `/packages/<package name>/versions`.
       // Fetch all versions for a package.
-      const { package_name } = versions_endpoint.groups;
+      const package_name = decodeURIComponent(versions_endpoint.groups.package_name);
       const version_prefix = `${package_name}/`;
 
       let version_names = [];
@@ -203,7 +213,8 @@ async function handleRequest(request, env, ctx, sentry) {
 
     if (version_endpoint !== null) {
       // Endpoint: `/packages/<package name>/versions/<version name>`.
-      const { package_name, version_name } = version_endpoint.groups;
+      const package_name = decodeURIComponent(version_endpoint.groups.package_name);
+      const version_name = decodeURIComponent(version_endpoint.groups.version_name);
       const version_key = `${package_name}/${version_name}`;
       const version_json = await env.CDNJS_VERSIONS.get(version_key);
       if (version_json === null) {

--- a/src/shadow.js
+++ b/src/shadow.js
@@ -277,7 +277,11 @@ export async function shadowCompare(newResponse, request, env, sentry) {
   if (Math.random() >= rate) return;
 
   const url = new URL(request.url);
-  const pathname = decodeURI(url.pathname);
+  // Keep pathname URL-encoded — it's used to reconstruct the upstream URL
+  // (`oldUrl` below) and as a key for Cache API / D1 markers, both of which
+  // want the raw routing-form. `decodeURI` was historically a no-op for the
+  // reserved chars (`@`, `&`, etc.) we actually care about anyway.
+  const pathname = url.pathname;
   const endpointType = classify(pathname);
   if (endpointType === "other") return;
 


### PR DESCRIPTION
## Bug

Reported by cdnjs-api-server returning a 500 for a real package version:

```json
{"error":true,"status":500,"message":"GET https://metadata.cdnjs.cloudflare.com/packages/scatterjs/versions/scatterjs-core%402.7.18: 404 Not Found","ref":"2b2da43a49a940b99bb89b772905fc4a"}
```

The KV key is `scatterjs/scatterjs-core@2.7.18`. The request URL has `%40` because cdnjs-api-server correctly encodes the version name with `encodeURIComponent`. Our worker decoded the pathname with `decodeURI`, which by design **does not** decode reserved characters — `@`, `&`, `+`, `=`, etc. So `%40` survived, and the KV lookup used the literal string `scatterjs/scatterjs-core%402.7.18`, which doesn't exist → 404.

Anything that hits a version named `<name>@<semver>` is affected. Likely also breaks any package with a literal `+`, `&`, or similar in its name or version.

## Fix

Keep `url.pathname` URL-encoded for routing and the existing regex matches (`[^/]+` works equally well on encoded segments). Decode each captured segment with `decodeURIComponent` at the point where it becomes a KV key or KV list prefix. Applied to all five regex-routed endpoints in `index.js`:

- `/packages/<name>`
- `/packages/<name>/sris` and `/packages/<name>/sris/<version>`
- `/packages/<name>/all`
- `/packages/<name>/versions`
- `/packages/<name>/versions/<version>` ← the reported one

### Why drop `decodeURI` in `shadow.js` too

`shadow.js` does not use `pathname` as a KV key. It uses it for three things:

1. `classify(pathname)` — regexes are `[^/]+`, match either form.
2. `oldUrl = \`${origin}${pathname}${url.search}\`` — must be encoded for a valid HTTP request upstream. `decodeURI` was a no-op for the reserved chars we care about, but for paths with literal spaces or unicode it would have produced an invalid URL.
3. Cache API / D1 marker keys — stable string either way; the encoded form is what `request.url` produced and is what other colos will produce too.

So keeping it encoded is strictly more correct.

### Minor migration note

D1 `shadow_mismatches` rows written before this change for paths containing literal spaces or unicode in package names would have been stored decoded. After this change, `isKnownMismatch` looks them up encoded and misses. Worst case: we re-detect a known mismatch once and re-insert the row. Acceptable.

📎 cloppy sim-ai